### PR TITLE
give the good mojang version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ urllib3==1.26.14
 GitPython
 python-dotenv
 youtube_dl
-mojang==1.0.0
+mojang==1.1.0
 moviepy
 uuid
 


### PR DESCRIPTION
Pip trouve pas la version actuellement indiquée, donc ça fait planter l'installation des paquets